### PR TITLE
fix: handle number value beside table

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ If you wish to require a player to have a phone item in their inventory, you mus
     "identifierColumn": "citizenid",
   },
   ```
+3. Navigate to the `config.lua` in `qbx-npwd` and verify all the items you want to work as a phone are listed.
 
 ## Other Features
 1. Double clicking any phone items in the inventory will open the phone. If you want to be able to drag and drop phone items over the Use button in the inventory, you must navigate to `qb-core/shared/items.lua`, find your phone item, and change `usable` to `true` and `shouldClose` to `true`.

--- a/README.md
+++ b/README.md
@@ -9,12 +9,21 @@
 
 ## Enabling PhoneAsItem Support
 If you wish to require a player to have a phone item in their inventory, you must follow the steps below.
-
 1. Navigate to the `config.json` in `npwd` and change the following settings under `PhoneAsItem`:
-	a. `enabled` to `true`
-	b. `exportResource` to `qbx-npwd`
-	c. `exportFunction` to `HasPhone`
-2. Navigate to the `config.lua` in `qbx-npwd` and verify all the items you want to work as a phone are listed.
+```json
+"PhoneAsItem": {
+    "enabled": true,
+    "exportResource": "qbx-npwd",
+    "exportFunction": "HasPhone"
+  },
+```
+2. Also in the  `config.json` in `npwd` change the following settings under `database`:
+```json
+  "database": {
+    "playerTable": "players",
+    "identifierColumn": "citizenid",
+  },
+  ```
 
 ## Other Features
 1. Double clicking any phone items in the inventory will open the phone. If you want to be able to drag and drop phone items over the Use button in the inventory, you must navigate to `qb-core/shared/items.lua`, find your phone item, and change `usable` to `true` and `shouldClose` to `true`.

--- a/client.lua
+++ b/client.lua
@@ -11,7 +11,7 @@ local function DoPhoneCheck(isUnload)
     local items = exports.ox_inventory:Search('count', Config.PhoneList)
 
     if type(items) == 'number' then
-        hasPhone = items > 0 and true
+        hasPhone = items > 0
     else
         for _, v in pairs(items) do
             if v > 0 then

--- a/client.lua
+++ b/client.lua
@@ -10,10 +10,14 @@ local function DoPhoneCheck(isUnload)
 
     local items = exports.ox_inventory:Search('count', Config.PhoneList)
 
-    for _, v in pairs(items) do
-        if v > 0 then
-            hasPhone = true
-            break
+    if type(items) == 'number' then
+        hasPhone = items > 0 and true
+    else
+        for _, v in pairs(items) do
+            if v > 0 then
+                hasPhone = true
+                break
+            end
         end
     end
 


### PR DESCRIPTION
In case of one item in the Config.PhoneList
`exports.ox_inventory:Search('count', Config.PhoneList)`
returns only a number instead of a table.

Fixed by checking the type of items variable